### PR TITLE
Bump "reqwest" dependency to make build work again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "League of Legends username availablity checker."
 
 [dependencies]
 ratelimit = "0.4.2"
-reqwest = "0.8.1"
+reqwest = "0.9.24"
 clap = "2.27.1"
 lazy_static = "0.2"
 fern = "0.4.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,7 @@ fn send_request(server: &str, api_key: &str, username: &str) -> Result<(), Box<E
     debug!("{:?}", resp);
 
     if !resp.status().is_success() {
-        if resp.status().eq(&StatusCode::NotFound) {
+        if resp.status().eq(&StatusCode::NOT_FOUND) {
             Ok(())
         } else {
             Err(Box::from("Bad response from Riot API"))


### PR DESCRIPTION
### Fix for:
```
error: failed to select a version for the requirement `security-framework = "^0.1.13"`
candidate versions found which didn't match: 2.8.2, 2.8.1, 2.8.0, ...
```